### PR TITLE
Update nvim-tree config to open at current file location

### DIFF
--- a/config/nvim/lua/mohammed/plugins/neo-tree.lua
+++ b/config/nvim/lua/mohammed/plugins/neo-tree.lua
@@ -1,0 +1,19 @@
+return {
+  'nvim-tree/nvim-tree.lua',
+  version = '*',
+  lazy = false,
+  dependencies = {
+    'nvim-tree/nvim-web-devicons',
+  },
+  config = function()
+    require('nvim-tree').setup({
+      update_focused_file = {
+        enable = true,
+      },
+      view = {
+        adaptive_size = true,
+      },
+    })
+    vim.api.nvim_set_keymap('n', '<C-h>', ':NvimTreeToggle<CR>', { noremap = true, silent = true })
+  end,
+}


### PR DESCRIPTION
Configure `nvim-tree` to open at the current file location and add adaptive size view.

* Add `update_focused_file` setting to `nvim-tree` setup with `enable` set to `true`.
* Add `view` setting to `nvim-tree` setup with `adaptive_size` set to `true`.
* Set key mapping for toggling the tree to `<C-h>`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/m7medVision/dotfiles/pull/1?shareId=75afec71-ced1-4a6b-b2a3-4b0d6ed54f0d).